### PR TITLE
Responsive Industries Page 

### DIFF
--- a/_includes/industry-summary.html
+++ b/_includes/industry-summary.html
@@ -17,12 +17,17 @@
     <a href="{{ include.link }}">
       <div class="box">
         <article class="media">
-          <div class="media-left">
+          <div class="media-left is-hidden-mobile">
             <div class="image is-20x15">
               <img src="{{ include.image }}" alt="{{ include.title }}" />
             </div>
           </div>
           <div class="media-content">
+            <div class="is-hidden-tablet" style="padding-bottom: 1rem;">
+              <div class="image">
+                <img src="{{ include.image }}" alt="{{ include.title }}" />
+              </div>
+            </div>
             <div class="content dark-text">
               <h3 class="title is-3 industry-title">{{ include.title }}</h3>
               <div class="has-text-weight-semibold">

--- a/industries/index.md
+++ b/industries/index.md
@@ -40,7 +40,7 @@ industries:
   <div class="content">
     <div class="dashboard">
       <!-- left panel -->
-      <div class="dashboard-panel is-one-quarter">
+      <div class="dashboard-panel is-one-quarter is-hidden-mobile">
         <aside class="menu">
           <p class="menu-label">
             Industries


### PR DESCRIPTION
Fixed the industries on the mobile page by removing the side bar and moving the image for the industry to the top of the card.