### PR TITLE
Fix Card Title Height

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -6,9 +6,8 @@
     </div>
     <div class="card-content">
       <div class="media">
-        <div class="media-content">
+        <div class="media-content has-text-centered">
           <p class="title is-4">{{ include.title }}</p>
-          <p class="subtitle is-6">{{ include.subtitle }}</p>
         </div>
       </div>
       <div class="content">


### PR DESCRIPTION
Fixes #7. We weren't using the `.media-content.subtitle` on the card, and it was causing issues with the `.media-content.title`, so I removed it. Also centered the `.title`.