### PR TITLE
Fix Text Overflows on Services Page

### DIFF
--- a/_sass/_shared.scss
+++ b/_sass/_shared.scss
@@ -94,15 +94,25 @@
     left: 50%;
     transform: translate(-50%, -50%);
     color: white;
+    @include mobile {
+      font-size: 1rem;
+    }
   }
 
   &__sub-text {
     position: absolute;
     width: 100%;
     padding: .75rem;
-    display: table-cell;
     font-size: 1.1rem;
-    color:white
+    color:white;
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    flex-direction: column;
+    height: 100%;
+    @include mobile {
+      font-size: 0.9rem;
+    }
   }
 
   &__subtitle {

--- a/services/index.md
+++ b/services/index.md
@@ -27,7 +27,7 @@ services:
             </div>
             <div class="info-card__subtitle">
                 <div class="info-card__sub-text">
-                    Whether your company is wanting to leverage a cloud environment for the first time, expand an existing deployment, or modernize the flow between on premise and cloud systems, we have engineers that have successfully done it all. 
+                    Whether your company is wanting to leverage a cloud environment for the first time, expand an existing deployment, or modernize the flow between on premise and cloud systems, we have engineers that have successfully done it all.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #22.

Decreased the `font-size` on `mobile` for the "text" and "sub-text" elements on the Services page. I vertically centered the sub-text in the `div` as well.

iPhone X:

<img width="457" alt="Screen Shot 2020-05-15 at 5 19 41 PM" src="https://user-images.githubusercontent.com/7366232/82101011-e0606880-96d0-11ea-8802-16a979abb1c8.png">
