### PR TITLE
Remove Old Pinned-Tab Icon Link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,13 +33,6 @@
     href="{{ '/assets/images/icons/apple-touch-icon.png' | relative_url }}"
   />
 
-  <!-- For macOS "Pinned Tab". -->
-  <link
-    rel="mask-icon"
-    href="{{ '/assets/images/icons/safari-pinned-tab.svg' | relative_url }}"
-    color="#ff7b24"
-  />
-
   <!-- For Android Chrome -->
   <link
     rel="icon"


### PR DESCRIPTION
This icon doesn't exist (the link was dead), and all the browsers appear to be using the favicon anyways:

Safari:

<img width="265" alt="Screen Shot 2020-05-15 at 5 39 03 PM" src="https://user-images.githubusercontent.com/7366232/82101806-274f5d80-96d3-11ea-9975-7a03643101cb.png">

Firefox:

<img width="303" alt="Screen Shot 2020-05-15 at 5 39 09 PM" src="https://user-images.githubusercontent.com/7366232/82101843-41893b80-96d3-11ea-9f1d-dd83d62767a1.png">

Chrome:

<img width="205" alt="Screen Shot 2020-05-15 at 5 40 58 PM" src="https://user-images.githubusercontent.com/7366232/82101849-45b55900-96d3-11ea-8e54-f160ad33f410.png">
